### PR TITLE
Multi-arch builds with GitHub Actions

### DIFF
--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -1,0 +1,47 @@
+name: Commit Stage
+
+on:
+  push:
+
+jobs:
+  publish-dockerfile:
+    name: Publish (Dockerfile)
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/publish-dockerfile.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [
+          {context: go/result, image: result-go},
+          {context: go/vote, image: vote-go},
+          {context: go/worker, image: worker-go},
+          {context: dotnet/worker, image: worker-dotnet},
+        ]
+    with:
+      context: ${{ matrix.project.context }}
+      image: ${{ matrix.project.image }}   
+    secrets:  
+      push-token: ${{ secrets.IMAGE_PUSH_TOKEN }}
+  
+  publish-java:
+    name: Publish (Java)
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    uses: ./.github/workflows/publish-java.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [
+          {context: java/echo, image: echo-java},
+          {context: java/vote, image: vote-java},
+        ]
+    with:
+      context: ${{ matrix.project.context }}
+      image: ${{ matrix.project.image }}   
+    secrets:  
+      push-token: ${{ secrets.IMAGE_PUSH_TOKEN }}

--- a/.github/workflows/publish-dockerfile.yml
+++ b/.github/workflows/publish-dockerfile.yml
@@ -1,0 +1,147 @@
+name: Build and Publish (Dockerfile)
+
+on:
+  workflow_call:
+    inputs:
+      context:
+        description: "Folder with build context."
+        required: true
+        type: string
+      image:
+        description: "Name of the OCI image."
+        required: true
+        type: string
+    secrets:
+      push-token:
+        description: "Image push token"
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: salaboy/${{ inputs.image }}
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Check out source code
+        uses: actions/checkout@v4
+      
+      - name: Generate Docker meta information
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          labels: |
+            org.opencontainers.image.licenses='Apache-2.0'
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ github.sha }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.push-token }}
+          registry: ${{ env.REGISTRY }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        id: build
+        with:
+          context: ${{ inputs.context }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ inputs.image }}-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [build]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ inputs.image }}-*
+          merge-multiple: true
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.4.0
+
+      - name: Generate Docker meta information
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          labels: |
+            org.opencontainers.image.licenses='Apache-2.0'
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ github.sha }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=long
+
+      - name: Login to container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.push-token }}
+          registry: ${{ env.REGISTRY }}
+      
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE }}@sha256:%s ' *)          
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+      
+      - name: Sign image
+        run: |
+          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -1,0 +1,159 @@
+name: Build and Publish (Java)
+
+on:
+  workflow_call:
+    inputs:
+      context:
+        description: "Folder with build context."
+        required: true
+        type: string
+      image:
+        description: "Name of the OCI image."
+        required: true
+        type: string
+    secrets:
+      push-token:
+        description: "Image push token"
+        required: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: salaboy/${{ inputs.image }}
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Check out source code
+        uses: actions/checkout@v4
+      
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+      
+      - name: Compile and test
+        run: |
+          cd ${{ inputs.context }}
+          chmod +x mvnw
+          ./mvnw package
+      
+      - name: Generate Docker meta information
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          labels: |
+            org.opencontainers.image.licenses='Apache-2.0'
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ github.sha }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.push-token }}
+          registry: ${{ env.REGISTRY }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        id: build
+        with:
+          context: ${{ inputs.context }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ inputs.image }}-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs: [build]
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ inputs.image }}-*
+          merge-multiple: true
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.4.0
+
+      - name: Generate Docker meta information
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          labels: |
+            org.opencontainers.image.licenses='Apache-2.0'
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ github.sha }}
+            org.opencontainers.image.url=${{ github.server_url }}/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=long
+
+      - name: Login to container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.push-token }}
+          registry: ${{ env.REGISTRY }}
+      
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE }}@sha256:%s ' *)          
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+      
+      - name: Sign image
+        run: |
+          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/dotnet/worker/Dockerfile
+++ b/dotnet/worker/Dockerfile
@@ -1,16 +1,8 @@
-# because of dotnet, we always build on amd64, and target platforms in cli
-# dotnet doesn't support QEMU for building or running. 
-# (errors common in arm/v7 32bit) https://github.com/dotnet/dotnet-docker/issues/1537
-# https://hub.docker.com/_/microsoft-dotnet
-# hadolint ignore=DL3029
-# to build for a different platform than your host, use --platform=<platform>
-# for example, if you were on Intel (amd64) and wanted to build for ARM, you would use:
-# docker buildx build --platform "linux/arm64/v8" .
-FROM --platform=${BUILDPLATFORM} mcr.microsoft.com/dotnet/sdk:7.0 as build
+# Build Image
+FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
 ARG TARGETPLATFORM
 ARG TARGETARCH
-ARG BUILDPLATFORM
-RUN echo "I am running on $BUILDPLATFORM, building for $TARGETPLATFORM"
+RUN echo "I am building for $TARGETPLATFORM"
 
 WORKDIR /source
 COPY *.csproj .

--- a/java/echo/Dockerfile
+++ b/java/echo/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.io/library/eclipse-temurin:21-jdk-jammy AS builder
+WORKDIR workspace
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
+
+FROM docker.io/library/eclipse-temurin:21-jre-jammy
+RUN useradd spring
+USER spring
+WORKDIR workspace
+COPY --from=builder workspace/dependencies/ ./
+COPY --from=builder workspace/spring-boot-loader/ ./
+COPY --from=builder workspace/snapshot-dependencies/ ./
+COPY --from=builder workspace/application/ ./
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/java/vote/Dockerfile
+++ b/java/vote/Dockerfile
@@ -1,0 +1,15 @@
+FROM docker.io/library/eclipse-temurin:21-jdk-jammy AS builder
+WORKDIR workspace
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
+
+FROM docker.io/library/eclipse-temurin:21-jre-jammy
+RUN useradd spring
+USER spring
+WORKDIR workspace
+COPY --from=builder workspace/dependencies/ ./
+COPY --from=builder workspace/spring-boot-loader/ ./
+COPY --from=builder workspace/snapshot-dependencies/ ./
+COPY --from=builder workspace/application/ ./
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/k8s-dapr-shared-and-knative/echo-kservice.yaml
+++ b/k8s-dapr-shared-and-knative/echo-kservice.yaml
@@ -12,7 +12,7 @@ spec:
         autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
-      - image: salaboy/examplevotingapp_echo:java
+      - image: ghcr.io/salaboy/echo-java
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/k8s-dapr-shared-and-knative/result-kservice.yaml
+++ b/k8s-dapr-shared-and-knative/result-kservice.yaml
@@ -10,7 +10,7 @@ spec:
         autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
-      - image: salaboy/examplevotingapp_result:go
+      - image: ghcr.io/salaboy/result-go
         imagePullPolicy: Always
         ports:
         - containerPort: 3000

--- a/k8s-dapr-shared-and-knative/vote-kservice.yaml
+++ b/k8s-dapr-shared-and-knative/vote-kservice.yaml
@@ -10,7 +10,7 @@ spec:
         autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
-      - image: salaboy/examplevotingapp_vote:java
+      - image: ghcr.io/salaboy/vote-java
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/k8s-dapr-shared-and-knative/worker-kservice.yaml
+++ b/k8s-dapr-shared-and-knative/worker-kservice.yaml
@@ -12,7 +12,7 @@ spec:
         autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
-      - image: salaboy/examplevotingapp_worker:dotnet
+      - image: ghcr.io/salaboy/worker-dotnet
         imagePullPolicy: Always
         env:
         - name: DAPR_HTTP_ENDPOINT

--- a/k8s-platform/app/app-echo.yaml
+++ b/k8s-platform/app/app-echo.yaml
@@ -12,7 +12,7 @@ spec:
         autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
-      - image: salaboy/examplevotingapp_echo:java
+      - image: ghcr.io/salaboy/echo-java
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/k8s-platform/app/app-result.yml
+++ b/k8s-platform/app/app-result.yml
@@ -10,7 +10,7 @@ spec:
         autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
-      - image: salaboy/examplevotingapp_result:go
+      - image: ghcr.io/salaboy/result-go
         imagePullPolicy: Always
         ports:
         - containerPort: 3000

--- a/k8s-platform/app/app-vote.yml
+++ b/k8s-platform/app/app-vote.yml
@@ -10,7 +10,7 @@ spec:
         autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
-      - image: salaboy/examplevotingapp_vote:java
+      - image: ghcr.io/salaboy/vote-java
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/k8s-platform/app/app-worker.yml
+++ b/k8s-platform/app/app-worker.yml
@@ -12,7 +12,7 @@ spec:
         autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
-      - image: salaboy/examplevotingapp_worker:dotnet
+      - image: ghcr.io/salaboy/worker-dotnet
         imagePullPolicy: Always
         env:
         - name: DAPR_HTTP_ENDPOINT


### PR DESCRIPTION
Configured GHA workflows to build multi-arch images for all applications and sign them with Sigstore.

To make the workflows work, you need to add a Secret named `IMAGE_PUSH_TOKEN` to the repository settings with a PAT having "packages (write)" permissions.

<img width="1143" alt="Screenshot 2024-03-01 at 07 19 19" src="https://github.com/salaboy/example-voting-app/assets/8523418/87d2acfb-4d3e-45ed-83e3-eb9387762625">

Is it ok to use GitHub Container Registry? Docker Hub would cause us issue with the rate limits, whereas GHCR wouldn't. I've been hitting the rate limits on the cloud cluster (locally it's better since I'm logged in, though I'm on an ARM machine, so the AMD-only images don't run that well).